### PR TITLE
Fix unspecified issue

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The devcontainer publish action needs contents: write permission to automatically create git tags after publishing templates. Previously it only had contents: read which caused tag creation to fail.