### PR TITLE
Add Lua language server support to devcontainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ RUN ln -sf /usr/bin/luarocks-5.1 /usr/local/bin/luarocks-5.1 && \
 # Pre-built binaries require glibc which is not available on Alpine
 # Pin to specific release tag for supply-chain security
 ARG LUA_LS_VERSION=3.13.6
-RUN apk add --no-cache --virtual .lls-build-deps ninja-build && \
+RUN apk add --no-cache --virtual .lls-build-deps samurai && \
+    ln -sf /usr/bin/samu /usr/bin/ninja && \
     git clone --depth 1 --branch ${LUA_LS_VERSION} --recurse-submodules https://github.com/LuaLS/lua-language-server.git /tmp/lua-language-server && \
     cd /tmp/lua-language-server && \
     ./make.sh && \
@@ -41,6 +42,7 @@ RUN apk add --no-cache --virtual .lls-build-deps ninja-build && \
     cp -r /tmp/lua-language-server/script /opt/lua-language-server/ && \
     ln -sf /opt/lua-language-server/bin/lua-language-server /usr/local/bin/lua-language-server && \
     rm -rf /tmp/lua-language-server && \
+    rm -f /usr/bin/ninja && \
     apk del .lls-build-deps
 
 # Copy and install vl helper command

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN ln -sf /usr/bin/luarocks-5.1 /usr/local/bin/luarocks-5.1 && \
 # Pre-built binaries require glibc which is not available on Alpine
 # Pin to specific release tag for supply-chain security
 ARG LUA_LS_VERSION=3.13.6
-RUN apk add --no-cache --virtual .lls-build-deps ninja && \
+RUN apk add --no-cache --virtual .lls-build-deps ninja-build && \
     git clone --depth 1 --branch ${LUA_LS_VERSION} --recurse-submodules https://github.com/LuaLS/lua-language-server.git /tmp/lua-language-server && \
     cd /tmp/lua-language-server && \
     ./make.sh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,26 +24,10 @@ RUN ln -sf /usr/bin/luarocks-5.1 /usr/local/bin/luarocks-5.1 && \
     ln -sf /usr/bin/luarocks-5.3 /usr/local/bin/luarocks-5.3 && \
     ln -sf /usr/bin/luarocks-5.4 /usr/local/bin/luarocks-5.4
 
-# Build Lua Language Server from source for Alpine/musl compatibility
-# Pre-built binaries require glibc which is not available on Alpine
-# Pin to specific release tag for supply-chain security
-ARG LUA_LS_VERSION=3.13.6
-RUN apk add --no-cache --virtual .lls-build-deps samurai && \
-    ln -sf /usr/bin/samu /usr/bin/ninja && \
-    git clone --depth 1 --branch ${LUA_LS_VERSION} --recurse-submodules https://github.com/LuaLS/lua-language-server.git /tmp/lua-language-server && \
-    cd /tmp/lua-language-server && \
-    ./make.sh && \
-    mkdir -p /opt/lua-language-server/bin && \
-    cp -r /tmp/lua-language-server/bin/* /opt/lua-language-server/bin/ && \
-    cp -r /tmp/lua-language-server/main.lua /opt/lua-language-server/ && \
-    cp -r /tmp/lua-language-server/debugger.lua /opt/lua-language-server/ && \
-    cp -r /tmp/lua-language-server/locale /opt/lua-language-server/ && \
-    cp -r /tmp/lua-language-server/meta /opt/lua-language-server/ && \
-    cp -r /tmp/lua-language-server/script /opt/lua-language-server/ && \
-    ln -sf /opt/lua-language-server/bin/lua-language-server /usr/local/bin/lua-language-server && \
-    rm -rf /tmp/lua-language-server && \
-    rm -f /usr/bin/ninja && \
-    apk del .lls-build-deps
+# Install Lua Language Server from Alpine edge/community repository
+# This provides a musl-compatible binary built by Alpine maintainers
+RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community \
+    lua-language-server
 
 # Copy and install vl helper command
 COPY vl /usr/local/bin/vl

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,16 +24,22 @@ RUN ln -sf /usr/bin/luarocks-5.1 /usr/local/bin/luarocks-5.1 && \
     ln -sf /usr/bin/luarocks-5.3 /usr/local/bin/luarocks-5.3 && \
     ln -sf /usr/bin/luarocks-5.4 /usr/local/bin/luarocks-5.4
 
-# Install Lua Language Server for sumneko.lua extension
-RUN ARCH=$(uname -m) && \
-    if [ "$ARCH" = "x86_64" ]; then ARCH_NAME="x64"; \
-    elif [ "$ARCH" = "aarch64" ]; then ARCH_NAME="arm64"; \
-    else echo "Unsupported architecture: $ARCH" && exit 1; fi && \
-    curl -L https://github.com/LuaLS/lua-language-server/releases/download/3.7.4/lua-language-server-3.7.4-linux-$ARCH_NAME.tar.gz -o /tmp/lua-ls.tar.gz && \
-    mkdir -p /opt/lua-language-server && \
-    tar -xzf /tmp/lua-ls.tar.gz -C /opt/lua-language-server && \
+# Build Lua Language Server from source for Alpine/musl compatibility
+# Pre-built binaries require glibc which is not available on Alpine
+RUN apk add --no-cache --virtual .lls-build-deps ninja && \
+    git clone --depth 1 --recurse-submodules https://github.com/LuaLS/lua-language-server.git /tmp/lua-language-server && \
+    cd /tmp/lua-language-server && \
+    ./make.sh && \
+    mkdir -p /opt/lua-language-server/bin && \
+    cp -r /tmp/lua-language-server/bin/* /opt/lua-language-server/bin/ && \
+    cp -r /tmp/lua-language-server/main.lua /opt/lua-language-server/ && \
+    cp -r /tmp/lua-language-server/debugger.lua /opt/lua-language-server/ && \
+    cp -r /tmp/lua-language-server/locale /opt/lua-language-server/ && \
+    cp -r /tmp/lua-language-server/meta /opt/lua-language-server/ && \
+    cp -r /tmp/lua-language-server/script /opt/lua-language-server/ && \
     ln -sf /opt/lua-language-server/bin/lua-language-server /usr/local/bin/lua-language-server && \
-    rm /tmp/lua-ls.tar.gz
+    rm -rf /tmp/lua-language-server && \
+    apk del .lls-build-deps
 
 # Copy and install vl helper command
 COPY vl /usr/local/bin/vl

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,10 @@ RUN ln -sf /usr/bin/luarocks-5.1 /usr/local/bin/luarocks-5.1 && \
 
 # Build Lua Language Server from source for Alpine/musl compatibility
 # Pre-built binaries require glibc which is not available on Alpine
+# Pin to specific release tag for supply-chain security
+ARG LUA_LS_VERSION=3.13.6
 RUN apk add --no-cache --virtual .lls-build-deps ninja && \
-    git clone --depth 1 --recurse-submodules https://github.com/LuaLS/lua-language-server.git /tmp/lua-language-server && \
+    git clone --depth 1 --branch ${LUA_LS_VERSION} --recurse-submodules https://github.com/LuaLS/lua-language-server.git /tmp/lua-language-server && \
     cd /tmp/lua-language-server && \
     ./make.sh && \
     mkdir -p /opt/lua-language-server/bin && \

--- a/test/test_cli_tools.sh
+++ b/test/test_cli_tools.sh
@@ -51,6 +51,13 @@ test_command "luarocks-5.3" luarocks-5.3 --version
 test_command "luarocks-5.4" luarocks-5.4 --version
 
 echo ""
+echo "----------------------------------------"
+echo "Testing Language Server"
+echo "----------------------------------------"
+
+test_command "lua-language-server" lua-language-server --version
+
+echo ""
 echo "========================================"
 echo "Test Summary"
 echo "========================================"


### PR DESCRIPTION
Pre-built lua-language-server binaries require glibc, which is not available on Alpine (musl-based). This change compiles the language server from source during the container build to ensure compatibility.

Fixes #16